### PR TITLE
Add www.gaslight.fun to ingress configuration in production environment

### DIFF
--- a/k8s/production/ingress.yaml
+++ b/k8s/production/ingress.yaml
@@ -23,3 +23,13 @@ spec:
                                     number: 80
                         path: /
                         pathType: Prefix
+        -   host: www.gaslight.fun
+            http:
+                paths:
+                    -   backend:
+                            service:
+                                name: frontend-service
+                                port:
+                                    number: 80
+                        path: /
+                        pathType: Prefix

--- a/k8s/staging/ingress.yaml
+++ b/k8s/staging/ingress.yaml
@@ -9,7 +9,6 @@ spec:
     ingressClassName: nginx
     tls:
         -   hosts:
-                - www.gaslight.fun
                 - staging.gaslight.fun
             secretName: frontend-tls
     rules:


### PR DESCRIPTION
Include www.gaslight.fun in the ingress configuration to route traffic to the frontend service in the production environment.